### PR TITLE
Allow to set `GROUPNAME` and avoid inferring it

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,13 @@ if ! command -v fixuid >/dev/null; then
   if [ -z "${USERNAME:-}" ]; then
     error "The USERNAME environment variable must be set."
   fi
-  GROUPNAME="$(id -gn "${USERNAME}")"
+  if ! getent passwd "${USERNAME}" >/dev/null; then
+    error "The user ${USERNAME} does not exist."
+  fi
+  GROUPNAME="${GROUPNAME:-"${USERNAME}"}"
+  if ! getent group "${GROUPNAME}" >/dev/null; then
+    error "The group ${GROUPNAME} does not exist."
+  fi
   fixuid_version='0.6.0'
   echo "Installing fixuid v${fixuid_version}"
   fixuid_url="https://github.com/boxboat/fixuid/releases/download/v${fixuid_version}/fixuid-${fixuid_version}-linux-$(dpkg --print-architecture).tar.gz"


### PR DESCRIPTION
This partially reverts e96e6955445c510ca7b18c27e669a3de507c2ec6, as I don't think it was a good idea.

But now, the user can pass a different groupname with `GROUPNAME` environment variable, like:

```dockerfile
ARG USERNAME=username
ARG GROUPNAME=groupname
RUN <fixdockergid>/install.sh
```

While still falling back to `USERNAME` if `GROUPNAME` is not set.

Also, to avoid issues in runtime, we verify the presence of the user and group during `install.sh` execution.
