### PR TITLE
Add support for `--use-api-socket`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 ARG BASE_IMAGE="buildpack-deps:noble"
-# Ubuntu 24.04 image comes with this user by default
-ARG USERNAME="ubuntu"
+ARG USERNAME="rootless"
 
 FROM ${BASE_IMAGE}-curl AS base
 
@@ -27,6 +26,20 @@ COPY --from=build /_fixdockergid /dist/_fixdockergid.linux_${TARGETARCH}
 
 # Contains non-root user and docker-cli
 FROM base AS docker-cli
+
+# Create non-root user
+ARG USERNAME
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN \
+  # Ubuntu 24.04 image comes with this user by default \
+  if getent passwd ubuntu >/dev/null; then \
+      userdel -r ubuntu; \
+  fi \
+  # Create non-root user \
+  && groupadd --gid "$USER_GID" "$USERNAME" \
+  && useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME"
 
 # Install Docker CLI
 RUN \

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ USER root
 # Replace with your non-root user name
 ARG USERNAME="rootless"
 # Replace with a git tag
-ARG FIXDOCKERGID_VERSION="0.7.3"
+ARG FIXDOCKERGID_VERSION="0.7.4"
 
 RUN curl -fsSL "https://github.com/felipecrs/fixdockergid/raw/v${FIXDOCKERGID_VERSION}/install.sh" | sh -
 

--- a/_fixdockergid.sh
+++ b/_fixdockergid.sh
@@ -50,4 +50,9 @@ if [ -S "${docker_sock}" ]; then
 
   fixuid_user_name="$(awk '/user:/ {print $2}' "${fixuid_config}")"
   usermod -a -G docker "${fixuid_user_name}"
+
+  docker_config_json='/run/secrets/docker/config.json'
+  if [ -f "${docker_config_json}" ]; then
+    chown "${fixuid_user_name}:${fixuid_group_name}" "${docker_config_json}"
+  fi
 fi

--- a/test.sh
+++ b/test.sh
@@ -96,6 +96,20 @@ function tests() {
   docker run "${run_options[@]}" -v /var/run/docker.sock:/var/run/docker.sock -u "${uid_gid}" "${container_name}" \
     docker version --format '{{.Server.Version}}'
 
+  # Test with --use-api-socket
+
+  # Add fake auth to config.json to trigger --use-api-socket config.json mounting
+  mkdir -p "${HOME}/.docker"
+  echo '{"auths":{"test":{"auth":"dGVzdC11c2VyLXRva2Vu"}}}' | tee "${HOME}/.docker/config.json"
+
+  # Confirm it's owned by root without fixdockergid
+  docker run "${run_options[@]}" --use-api-socket -u "${uid_gid}" --entrypoint= "${container_name}" \
+    stat -c '%U' /run/secrets/docker/config.json | tee /dev/stderr | grep -q "^root$"
+
+  # Confirm it's owned by the user with fixdockergid
+  docker run "${run_options[@]}" --use-api-socket -u "${uid_gid}" "${container_name}" \
+    stat -c '%U' /run/secrets/docker/config.json | tee /dev/stderr | grep -q "^${expected_user_name}$"
+
   if [[ "${expected_user_name}" != "root" && "${current_gid}" != "${current_docker_gid}" ]]; then
     # Confirm it doesn't work without fixdockergid
     {

--- a/test.sh
+++ b/test.sh
@@ -89,7 +89,7 @@ function tests() {
       groups | tee /dev/stderr | grep -q "^${expected_user_name}$"
   else
     docker run "${run_options[@]}" -v /var/run/docker.sock:/var/run/docker.sock -u "${uid_gid}" "${container_name}" \
-      groups | tee /dev/stderr | grep -q -E "^(${expected_user_name} docker)|(docker ${expected_user_name})$"
+      groups | tee /dev/stderr | grep -E "(^| )${expected_user_name}( |$)" | grep -q -E "(^| )docker( |$)"
   fi
 
   # Confirm fixdockergid is working
@@ -102,7 +102,7 @@ function tests() {
       docker run "${run_options[@]}" -v /var/run/docker.sock:/var/run/docker.sock -u "${uid_gid}" --entrypoint= "${container_name}" \
         docker version --format '{{.Server.Version}}' 2>&1 || true
     } |
-      grep 'dial unix /var/run/docker.sock: connect: permission denied'
+      grep 'permission denied'
   fi
 
   # Test docker exec with --group-add=docker
@@ -119,7 +119,7 @@ function tests() {
       docker exec "${container_name}" \
         docker version --format '{{.Server.Version}}' 2>&1 || true
     } |
-      grep 'dial unix /var/run/docker.sock: connect: permission denied'
+      grep 'permission denied'
     docker rm -f "${container_name}"
   fi
 }


### PR DESCRIPTION
In fact it already worked, except that `--use-api-socket` mounts the user's `~/.docker/config.json` into the container owned by root.

Now `fixdockergid` also changes the ownership of the mounted `config.json` to the non-root user, so that `docker` commands that require access to it (e.g. `docker login`) work without permission issues.