### PR TITLE
Fix ownership of `/run/secrets/docker` directory

### DIFF
--- a/_fixdockergid.sh
+++ b/_fixdockergid.sh
@@ -11,6 +11,8 @@ error() {
   exit 1
 }
 
+uid_gid="${1}"
+
 fixuid_config='/etc/fixuid/config.yml'
 
 if [ ! -f "${fixuid_config}" ]; then
@@ -51,8 +53,8 @@ if [ -S "${docker_sock}" ]; then
   fixuid_user_name="$(awk '/user:/ {print $2}' "${fixuid_config}")"
   usermod -a -G docker "${fixuid_user_name}"
 
-  docker_config_json='/run/secrets/docker/config.json'
-  if [ -f "${docker_config_json}" ]; then
-    chown "${fixuid_user_name}:${fixuid_group_name}" "${docker_config_json}"
+  docker_secrets_dir='/run/secrets/docker'
+  if [ -d "${docker_secrets_dir}" ]; then
+    chown -R "${uid_gid}" "${docker_secrets_dir}"
   fi
 fi

--- a/install.sh
+++ b/install.sh
@@ -92,9 +92,10 @@ current_uid="\$(id -u)"
 if [ "\${current_uid}" = 0 ]; then
   exec "\$@"
 fi
-unset current_uid
 
-'${fixdockergid_dir}/${_fixdockergid_filename}'
+current_gid="\$(id -g)"
+
+'${fixdockergid_dir}/${_fixdockergid_filename}' "\${current_uid}:\${current_gid}"
 
 exec fixuid \${fixuid_flags} -- "\$@"
 EOF

--- a/test.sh
+++ b/test.sh
@@ -98,15 +98,22 @@ function tests() {
 
   # Test with --use-api-socket
 
-  # Add fake auth to config.json to trigger --use-api-socket config.json mounting
+  # Populate ~/.docker/config.json to trigger --use-api-socket mounting
   mkdir -p "${HOME}/.docker"
-  echo '{"auths":{"test":{"auth":"dGVzdC11c2VyLXRva2Vu"}}}' | tee "${HOME}/.docker/config.json"
+  echo '{"auths":{"example.com":{"auth":"Zm9vOmJhcgo="}}}' | tee "${HOME}/.docker/config.json"
+
+  # Populate ~/.docker/buildx to trigger --use-api-socket buildx mounting
+  docker buildx build -f - . <<<"FROM scratch"
 
   # Confirm it's owned by root without fixdockergid
+  docker run "${run_options[@]}" --use-api-socket -u "${uid_gid}" --entrypoint= "${container_name}" \
+    stat -c '%U' /run/secrets/docker | tee /dev/stderr | grep -q "^root$"
   docker run "${run_options[@]}" --use-api-socket -u "${uid_gid}" --entrypoint= "${container_name}" \
     stat -c '%U' /run/secrets/docker/config.json | tee /dev/stderr | grep -q "^root$"
 
   # Confirm it's owned by the user with fixdockergid
+  docker run "${run_options[@]}" --use-api-socket -u "${uid_gid}" "${container_name}" \
+    stat -c '%U' /run/secrets/docker | tee /dev/stderr | grep -q "^${expected_user_name}$"
   docker run "${run_options[@]}" --use-api-socket -u "${uid_gid}" "${container_name}" \
     stat -c '%U' /run/secrets/docker/config.json | tee /dev/stderr | grep -q "^${expected_user_name}$"
 


### PR DESCRIPTION
Useful with `--use-api-socket` and trying to `docker build` inside the container, as it will try to populate `/run/secrets/docker/buildx` which therefore requires permission.